### PR TITLE
better sanitize handling in read_sdf

### DIFF
--- a/datamol/io.py
+++ b/datamol/io.py
@@ -106,7 +106,7 @@ def read_sdf(
 
     # File-like object
     if isinstance(urlpath, io.IOBase):
-        supplier = Chem.rdBase.ForwardSDMolSupplier(
+        supplier = Chem.ForwardSDMolSupplier(
             urlpath,
             sanitize=False,
             strictParsing=strict_parsing,
@@ -119,7 +119,7 @@ def read_sdf(
             if str(urlpath).endswith(".gz") or str(urlpath).endswith(".gzip"):
                 f = gzip.open(f)
 
-            supplier = Chem.rdBase.ForwardSDMolSupplier(
+            supplier = Chem.ForwardSDMolSupplier(
                 f,
                 sanitize=False,
                 strictParsing=strict_parsing,
@@ -165,7 +165,7 @@ def to_sdf(
 
     # File-like object
     if isinstance(urlpath, io.IOBase):
-        writer = Chem.rdBase.SDWriter(urlpath)
+        writer = Chem.SDWriter(urlpath)
         for mol in mols:
             writer.write(mol)
         writer.close()
@@ -173,7 +173,7 @@ def to_sdf(
     # Regular local or remote paths
     else:
         with fsspec.open(urlpath, mode="w") as f:
-            writer = Chem.rdBase.SDWriter(f)
+            writer = Chem.SDWriter(f)
             for mol in mols:
                 writer.write(mol)
             writer.close()
@@ -200,7 +200,7 @@ def to_smi(
 
     # File-like object
     if isinstance(urlpath, io.IOBase):
-        writer = Chem.rdBase.SmilesWriter(urlpath, includeHeader=False, nameHeader="")
+        writer = Chem.SmilesWriter(urlpath, includeHeader=False, nameHeader="")
         for mol in mols:
             writer.write(mol)
         writer.close()
@@ -208,7 +208,7 @@ def to_smi(
     # Regular local or remote paths
     else:
         with fsspec.open(urlpath, "w") as f:
-            writer = Chem.rdBase.SmilesWriter(f, includeHeader=False, nameHeader="")
+            writer = Chem.SmilesWriter(f, includeHeader=False, nameHeader="")
             for mol in mols:
                 writer.write(mol)
             writer.close()
@@ -236,7 +236,7 @@ def read_smi(
         dm.utils.fs.copy_file(urlpath, active_path)
 
     # Read the molecules
-    supplier = Chem.rdBase.SmilesMolSupplier(str(active_path), titleLine=0)
+    supplier = Chem.SmilesMolSupplier(str(active_path), titleLine=0)
     mols = [mol for mol in supplier if mol is not None]
 
     # Delete the local temporary path

--- a/datamol/io.py
+++ b/datamol/io.py
@@ -111,11 +111,13 @@ def read_sdf(
             sanitize=False,
             strictParsing=strict_parsing,
         )
-        mols = [mol for mol in supplier if mol is not None]
+        mols = list(supplier)
 
     # Regular local or remote paths
     else:
         with fsspec.open(urlpath) as f:
+
+            # Handle gzip file if needed
             if str(urlpath).endswith(".gz") or str(urlpath).endswith(".gzip"):
                 f = gzip.open(f)
 
@@ -124,11 +126,17 @@ def read_sdf(
                 sanitize=False,
                 strictParsing=strict_parsing,
             )
-            mols = [mol for mol in supplier if mol is not None]
+            mols = list(supplier)
 
+
+    # Sanitize
     if sanitize == True:
         mols = [dm.sanitize_mol(mol) for mol in mols]
 
+    # Discard None values
+    mols = [mol for mol in mols if mol is not None]
+
+    # Convert to dataframe
     if as_df:
         return dm.to_df(
             mols,

--- a/datamol/io.py
+++ b/datamol/io.py
@@ -106,7 +106,9 @@ def read_sdf(
 
     # File-like object
     if isinstance(urlpath, io.IOBase):
-        supplier = Chem.ForwardSDMolSupplier(urlpath, sanitize=sanitize, strictParsing=strict_parsing)
+        supplier = Chem.ForwardSDMolSupplier(
+            urlpath, sanitize=sanitize, strictParsing=strict_parsing
+        )
         mols = [mol for mol in supplier if mol is not None]
 
     # Regular local or remote paths

--- a/datamol/io.py
+++ b/datamol/io.py
@@ -93,7 +93,7 @@ def read_sdf(
 
     Args:
         urlpath: Path to a file or a file-like object. Path can be remote or local.
-        sanitize: Whether to sanitize the molecules with `dm.sanitize_mol`.
+        sanitize: Whether to sanitize the molecules.
         as_df: Whether to return a list mol or a pandas DataFrame.
         smiles_column: Name of the SMILES column. Only relevant if `as_df` is True.
         mol_column: Name of the mol column. Only relevant if `as_df` is True.
@@ -108,7 +108,7 @@ def read_sdf(
     if isinstance(urlpath, io.IOBase):
         supplier = Chem.ForwardSDMolSupplier(
             urlpath,
-            sanitize=False,
+            sanitize=sanitize,
             strictParsing=strict_parsing,
         )
         mols = list(supplier)
@@ -123,14 +123,10 @@ def read_sdf(
 
             supplier = Chem.ForwardSDMolSupplier(
                 f,
-                sanitize=False,
+                sanitize=sanitize,
                 strictParsing=strict_parsing,
             )
             mols = list(supplier)
-
-    # Sanitize
-    if sanitize == True:
-        mols = [dm.sanitize_mol(mol) for mol in mols]
 
     # Discard None values
     mols = [mol for mol in mols if mol is not None]
@@ -149,7 +145,7 @@ def read_sdf(
 
 
 def to_sdf(
-    mols: Union[Sequence[Chem.rdchem.Mol], pd.DataFrame],
+    mols: Union[Chem.rdchem.Mol, Sequence[Chem.rdchem.Mol], pd.DataFrame],
     urlpath: Union[str, os.PathLike, TextIO],
     smiles_column: Optional[str] = "smiles",
     mol_column: str = None,
@@ -157,7 +153,7 @@ def to_sdf(
     """Write molecules to a file.
 
     Args:
-        mols: a dataframe or a list of molecule.
+        mols: a dataframe, a molecule or a list of molecule.
         urlpath: Path to a file or a file-like object. Path can be remote or local.
         smiles_column: Column name to extract the molecule.
         mol_column: Column name to extract the molecule. It takes
@@ -166,6 +162,9 @@ def to_sdf(
 
     if isinstance(mols, pd.DataFrame):
         mols = dm.from_df(mols, smiles_column=smiles_column, mol_column=mol_column)
+
+    elif isinstance(mols, Chem.rdchem.Mol):
+        mols = [mols]
 
     # Filter out None values
     mols = [mol for mol in mols if mol is not None]

--- a/datamol/io.py
+++ b/datamol/io.py
@@ -128,7 +128,6 @@ def read_sdf(
             )
             mols = list(supplier)
 
-
     # Sanitize
     if sanitize == True:
         mols = [dm.sanitize_mol(mol) for mol in mols]

--- a/datamol/mol.py
+++ b/datamol/mol.py
@@ -578,7 +578,7 @@ def set_dative_bonds(
     Returns:
         The modified molecule.
     """
-    rwmol = Chem.rdBase.RWMol(mol)
+    rwmol = Chem.RWMol(mol)
     rwmol.UpdatePropertyCache(strict=False)
 
     metals = [at for at in rwmol.GetAtoms() if is_transition_metal(at)]

--- a/datamol/mol.py
+++ b/datamol/mol.py
@@ -74,7 +74,7 @@ def to_mol(
 
     # Add hydrogens
     if _mol is not None and add_hs:
-        _mol = Chem.AddHs(_mol, explicitOnly=explicit_only)
+        _mol = Chem.AddHs(_mol, explicitOnly=explicit_only, addCoords=True)
 
     # Reorder atoms
     if _mol is not None and ordered:
@@ -160,6 +160,7 @@ def sanitize_mol(
     charge_neutral: bool = False,
     sanifix: bool = True,
     verbose: bool = True,
+    add_hs: bool = False,
 ) -> Optional[Chem.rdchem.Mol]:
     """An augmented version of RDKit `sanitize=True`. It uses a
     mol-SMILES-mol conversion to catch potential aromaticity errors
@@ -178,6 +179,8 @@ def sanitize_mol(
         sanifix: whether to run the sanifix from James Davidson
             (sanifix4.py) that try to adjust aromatic nitrogens.
         verbose: Whether displaying a warning about multiple conformers.
+        add_hs: Add hydrogens to the returned molecule. Useful when the input
+            molecule already contains hydrogens.
 
     Returns:
         mol: a molecule.
@@ -206,7 +209,7 @@ def sanitize_mol(
         # Try catch to avoid occasional aromaticity errors
         try:
             # `cxsmiles` is used here to preserve the first conformer.
-            mol = to_mol(dm.to_smiles(mol, cxsmiles=True), sanitize=True)  # type: ignore
+            mol = to_mol(dm.to_smiles(mol, cxsmiles=True), sanitize=True, add_hs=add_hs)  # type: ignore
         except Exception:
             mol = None
 

--- a/datamol/mol.py
+++ b/datamol/mol.py
@@ -176,8 +176,6 @@ def sanitize_mol(
     original_mol = copy_mol(mol)
     properties = original_mol.GetPropsAsDict()
 
-    # Sanitize
-
     if charge_neutral:
         mol = to_neutral(mol)
 

--- a/datamol/mol.py
+++ b/datamol/mol.py
@@ -172,10 +172,9 @@ def sanitize_mol(
     if mol is None:
         return mol
 
-    # Extract properties and conformers
+    # Extract properties.
     original_mol = copy_mol(mol)
     properties = original_mol.GetPropsAsDict()
-    conformers = list(original_mol.GetConformers())
 
     # Sanitize
 
@@ -193,9 +192,8 @@ def sanitize_mol(
             mol = None
 
     if mol is not None:
-        # Insert back properties and conformers
+        # Insert back properties.
         mol = dm.set_mol_props(mol, properties)
-        [mol.AddConformer(conf) for conf in conformers]
 
     return mol
 

--- a/env.yml
+++ b/env.yml
@@ -44,8 +44,6 @@ dependencies:
   - markdown-include
   - mdx_truly_sane_lists
   - mike >=1.0.0
-  - markdown-it-py ==0.6.2  # no direct deps
-  - mkdocs-autorefs =0.1  # no direct deps
 
   # Releasing tools
   - rever >=0.4.5

--- a/news/sanitize-sdf.rst
+++ b/news/sanitize-sdf.rst
@@ -5,6 +5,8 @@
 **Changed:**
 
 * Allow input a single molecule to `dm.to_sdf` instead of a list of mol.
+* Preserve mol properties and the frist conformer in `dm.sanitize_mol`.
+* Display a warning message when input mol has multiple conformers in `dm.sanitize_mol`.
 
 **Deprecated:**
 

--- a/news/sanitize-sdf.rst
+++ b/news/sanitize-sdf.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Change former `sanitize` into `sanitize_mol` and use `sanitize` for `ForwardSDMolSupplier`.
+
+**Security:**
+
+* <news item>

--- a/news/sanitize-sdf.rst
+++ b/news/sanitize-sdf.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* <news item>
+* Allow input a single molecule to `dm.to_sdf` instead of a list of mol.
 
 **Deprecated:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Change former `sanitize` into `sanitize_mol` and use `sanitize` for `ForwardSDMolSupplier`.
+* Remove call to `sanitize_mol` in `read_sdf`, instead use `sanitize=True` from RDKit.
 
 **Security:**
 

--- a/news/sanitize-sdf.rst
+++ b/news/sanitize-sdf.rst
@@ -2,6 +2,7 @@
 
 * Add a sanitize flag to `from_df`.
 * Automatically detect the mol column in `from_df`.
+* Add `add_hs` arg to `sanitize_mol`.
 
 **Changed:**
 

--- a/news/sanitize-sdf.rst
+++ b/news/sanitize-sdf.rst
@@ -1,6 +1,7 @@
 **Added:**
 
 * Add a sanitize flag to `from_df`.
+* Automatically detect the mol column in `from_df`.
 
 **Changed:**
 

--- a/news/sanitize-sdf.rst
+++ b/news/sanitize-sdf.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* <news item>
+* Add a sanitize flag to `from_df`.
 
 **Changed:**
 
@@ -19,6 +19,7 @@
 **Fixed:**
 
 * Remove call to `sanitize_mol` in `read_sdf`, instead use `sanitize=True` from RDKit.
+* Remove the `mol` column from the mol properties in `from_df`. It also fixes `to_sdf`.
 
 **Security:**
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -169,11 +169,10 @@ def test_to_df_smiles_warning(datadir, caplog):
 
     assert sum(df.columns == "smiles") == 2
 
-    for record in caplog.records:
-        assert record.levelname != "WARNING"
+    assert "WARNING" in caplog.text
     assert (
         "The SMILES column name provided ('smiles') is already present in the properties of the molecules"
-        not in caplog.text
+        in caplog.text
     )
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -189,3 +189,19 @@ def test_to_smiles_fail():
     # NOTE(hadim): ideally you want to catch only `Boost.Python.ArgumentError` here.
     with pytest.raises(Exception):
         dm.to_smiles(55, allow_to_fail=True)
+
+
+def test_from_df_pop_mol_column():
+    df = dm.data.freesolv().iloc[:10]  # type: ignore
+    mols = [dm.to_mol(smiles) for smiles in df["smiles"]]
+
+    df: pd.DataFrame = dm.to_df(mols, mol_column="mol")  # type: ignore
+    df["dummy"] = "hello"
+
+    # test with provided mol column
+    mols = dm.from_df(df.copy(), mol_column="mol")
+    assert set(mols[0].GetPropsAsDict().keys()) == {"smiles", "dummy"}
+
+    # test with automatic mol column detection
+    mols = dm.from_df(df.copy())
+    assert set(mols[0].GetPropsAsDict().keys()) == {"smiles", "dummy"}

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,6 +4,7 @@ import io
 from rdkit import Chem
 
 import datamol as dm
+import numpy as np
 
 
 def test_read_csv(datadir):
@@ -177,4 +178,28 @@ def test_to_sdf_single_mol(tmp_path):
 
 
 def test_sdf_props_and_conformer_preserved(tmp_path):
-    pass
+
+    sdf_path = tmp_path / "test.sdf"
+
+    # Generate an SDF file
+    props = dict(test_int=588, test_str="hello")
+    smiles = "CC1(C2C(C3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4O)O)O)O)C(=O)N)N(C)C)O)O"
+
+    mol = dm.to_mol(smiles)
+    mol = dm.set_mol_props(mol, props)
+    mol = dm.conformers.generate(mol, n_confs=1)
+    pos = mol.GetConformer().GetPositions()
+    dm.to_sdf(mol, sdf_path)
+
+    # Read sdf file
+    mols = dm.read_sdf(sdf_path)
+    mol = mols[0]
+
+    # Check properties
+    assert mol.GetPropsAsDict() == props
+
+    # Check conformer
+    conf = mol.GetConformer()
+    assert mol.GetNumConformers() == 1
+    assert conf.Is3D()
+    np.testing.assert_almost_equal(conf.GetPositions(), pos, decimal=4)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -162,3 +162,19 @@ def test_to_from_text(tmp_path):
     file_like = io.StringIO()
     dm.to_smi(mols, file_like)
     assert file_like.getvalue().strip().split("\n") == smiles_list
+
+
+def test_to_sdf_single_mol(tmp_path):
+
+    sdf_path = tmp_path / "test.sdf"
+
+    smiles = "CC1(C2C(C3C(C(=O)C(=C(C3(C(=O)C2=C(C4=C1C=CC=C4O)O)O)O)C(=O)N)N(C)C)O)O"
+    mol = dm.to_mol(smiles)
+    dm.to_sdf(mol, sdf_path)
+
+    mols = dm.read_sdf(sdf_path)
+    assert dm.to_smiles(mol) == dm.to_smiles(mols[0])
+
+
+def test_sdf_props_and_conformer_preserved(tmp_path):
+    pass


### PR DESCRIPTION
Checklist:

- [x] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [x] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

Calling `dm.sanitize_mol` delete the conformers which should not happens by default since you often want the 3d structure when you read an SDF file.

(bug spotted while running unit tests on `berth` with a recent version of datamol)