### PR TITLE
Use native batch_size from joblib

### DIFF
--- a/datamol/utils/jobs.py
+++ b/datamol/utils/jobs.py
@@ -3,7 +3,6 @@ from typing import Sequence
 from typing import Callable
 from typing import Optional
 from typing import Any
-from typing import List
 
 import contextlib
 import itertools
@@ -154,7 +153,7 @@ class JobRunner:
             return data, total_length, original_length
 
         # If batch_size is set, the length of the inputs must be defined.
-        if total_length is None or not isinstance(data, Sequence):
+        if total_length is None or not isinstance(data, Iterable):
             raise ValueError(
                 f"batch_size is set to {self.batch_size} but the length of the input data are not defined (`__len__()`)."
             )

--- a/news/sequence.rst
+++ b/news/sequence.rst
@@ -12,7 +12,7 @@
 
 **Removed:**
 
-* <news item>
+* Revert batch_size fix to use default joblib instead
 
 **Fixed:**
 

--- a/news/sequence.rst
+++ b/news/sequence.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Issue #58: sequence bug in parallel.
+
+**Security:**
+
+* <news item>

--- a/tests/test_utils_jobs.py
+++ b/tests/test_utils_jobs.py
@@ -147,7 +147,7 @@ class TestJobs(unittest.TestCase):
 
     def test_with_batch_size(self):
         def _fn(n):
-            return n
+            return n * 3
 
         def _fn_return_none(n):
             return None

--- a/tests/test_utils_jobs.py
+++ b/tests/test_utils_jobs.py
@@ -2,6 +2,7 @@ import math
 import numbers
 import operator
 import unittest
+import numpy as np
 from functools import reduce
 
 import datamol as dm
@@ -42,10 +43,16 @@ class TestJobs(unittest.TestCase):
         )
         self.assertEqual(o4, [6, 4 * 5 * 6, 0])
 
+        o5 = jobrunner(random_fn, np.asarray([9, 25, 1024]), op="add")
+        self.assertEqual(o5, [9, 25, 1024])
+
     def test_parallel(self):
         jobrunner1 = dm.JobRunner(n_jobs=4, progress=True)  # use loky backend
         o1 = jobrunner1(random_fn, [9, 25, 1024], op="add")
         self.assertEqual(o1, [9, 25, 1024])
+
+        o5 = jobrunner1(random_fn, np.asarray([9, 25, 1024]), op="add")
+        self.assertEqual(o5, [9, 25, 1024])
 
         o3 = jobrunner1(random_fn, [(1, 2, 3), (4, 5, 6), (3, 4, 0)], arg_type="args", op="mul")
         self.assertEqual(o3, [6, 4 * 5 * 6, 0])


### PR DESCRIPTION
Fix #58 by replacing `Sequence` by `Iterable`.

I had the same bug a few hours ago.  @DomInvivo 

Checklist:

- [x] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [ ] Update the API documentation is a new function is added or an existing one is deleted.
- [x] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---
