### PR TITLE
Allowing flexible params for conformers and fallback options

### DIFF
--- a/datamol/conformers/_conformers.py
+++ b/datamol/conformers/_conformers.py
@@ -144,8 +144,7 @@ def generate(
                 f"Conformers embedding failed for {dm.to_smiles(mol)}. Trying with random coordinates."
             )
 
-        if fallback_to_random_coords:
-            params.useRandomCoords = True
+        params.useRandomCoords = True
         confs = AllChem.EmbedMultipleConfs(mol, numConfs=n_confs, params=params)
 
     if len(confs) == 0:

--- a/datamol/conformers/_conformers.py
+++ b/datamol/conformers/_conformers.py
@@ -35,7 +35,7 @@ def generate(
     add_hs: bool = True,
     fallback_to_random_coords: bool = True,
     ignore_failure: bool = False,
-    custom_embed_params: dict = None,
+    embed_params: dict = None,
     verbose: bool = False,
 ) -> Chem.rdchem.Mol:
     """Compute conformers of a molecule.
@@ -87,7 +87,7 @@ def generate(
         fallback_to_random_coords: Whether to use random coordinate initializations as a fallback if the initial
             embedding fails.
         ignore_failure: It set to True, this will avoid raising an error when the embedding fails and return None instead.
-        custom_embed_params: Allows the user to specify arbitrary embedding parameters for the conformers. See the Rdkit
+        embed_params: Allows the user to specify arbitrary embedding parameters for the conformers. See the Rdkit
             docs for reference. This will override any other default settings.
         verbose: Wether to enable logs during the process.
 
@@ -133,8 +133,8 @@ def generate(
     params = getattr(AllChem, method)()
     params.randomSeed = random_seed
     params.enforceChirality = True
-    if custom_embed_params is not None:
-        for k, v in custom_embed_params.items():
+    if embed_params is not None:
+        for k, v in embed_params.items():
             setattr(params, k, v)
 
     confs = AllChem.EmbedMultipleConfs(mol, numConfs=n_confs, params=params)
@@ -154,6 +154,10 @@ def generate(
 
     if len(confs) == 0:
         if ignore_failure:
+            if verbose:
+                logger.warning(
+                    f"Conformers embedding failed for {dm.to_smiles(mol)}. Returning None because ignore_failure is set."
+                )
             return None
         raise ValueError(f"Conformers embedding failed for {dm.to_smiles(mol)}")
 

--- a/datamol/conformers/_conformers.py
+++ b/datamol/conformers/_conformers.py
@@ -1,7 +1,5 @@
 from typing import Union
 from typing import List
-from typing import Dict
-from typing import Any
 from typing import Sequence
 from typing import Optional
 
@@ -140,14 +138,12 @@ def generate(
     confs = AllChem.EmbedMultipleConfs(mol, numConfs=n_confs, params=params)
 
     # Sometime embedding fails. Here we try again by disabling `enforceChirality`.
-    if len(confs) == 0:
+    if len(confs) == 0 and fallback_to_random_coords:
         if verbose:
             logger.warning(
-                f"Conformers embedding failed for {dm.to_smiles(mol)}. Trying without enforcing chirality and with random coordinates (if set)."
+                f"Conformers embedding failed for {dm.to_smiles(mol)}. Trying with random coordinates."
             )
-        params = getattr(AllChem, method)()
-        params.randomSeed = random_seed
-        params.enforceChirality = False
+
         if fallback_to_random_coords:
             params.useRandomCoords = True
         confs = AllChem.EmbedMultipleConfs(mol, numConfs=n_confs, params=params)

--- a/news/conformer_params.rst
+++ b/news/conformer_params.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Parameters allowing to customize or ignore failures when running the conformer generation.
+
+**Changed:**
+
+* When the conformer embedding fails, it will now optionally fall back to using random coordinates.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -20,7 +20,7 @@ def test_generate():
 
     mol = dm.to_mol(smiles)
     mol = dm.conformers.generate(
-        mol, rms_cutoff=None, minimize_energy=False, custom_embed_params={"useRandomCoords": True}
+        mol, rms_cutoff=None, minimize_energy=False, embed_params={"useRandomCoords": True}
     )
     assert mol.GetNumConformers() == 50
     assert mol.GetConformer(0).GetPositions().shape == (4, 3)

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -18,6 +18,18 @@ def test_generate():
     assert mol.GetNumConformers() == 50
     assert mol.GetConformer(0).GetPositions().shape == (4, 3)
 
+    mol = dm.to_mol(smiles)
+    mol = dm.conformers.generate(
+        mol, rms_cutoff=None, minimize_energy=False, custom_embed_params={"useRandomCoords": True}
+    )
+    assert mol.GetNumConformers() == 50
+    assert mol.GetConformer(0).GetPositions().shape == (4, 3)
+
+    # This mol should fail
+    smiles = "C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC"
+    mol = dm.to_mol(smiles)
+    assert dm.conformers.generate(mol, n_confs=1, verbose=True, ignore_failure=True) is None
+
     smiles = "CCCC"
     mol = dm.to_mol(smiles)
     mol = dm.conformers.generate(mol, rms_cutoff=None, minimize_energy=True)


### PR DESCRIPTION
This PR is to enable additional flexibility when using datamol for generating conformers. For example, it enables falling back to random coordinate initialization when the embedding fails, in addition to allowing specification of arbitrary embedding parameters compatible with rdkit.