### PR TITLE
expose clean_it arg

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install black
         run: |
-          pip install black==20.8b1
+          pip install black
 
       - name: Lint
         run: black --check .
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install mypy
         run: |
-          pip install mypy==0.812 numpy pandas loguru pytest pillow scipy
+          pip install mypy numpy pandas loguru pytest pillow scipy
 
       - name: Run code check
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          mamba create -n datamol
+          conda create -n datamol
           conda activate datamol
           mamba env update -f env.yml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
             > env-patched.yml
 
           # Create conda env
-          mamba create -n datamol
+          conda create -n datamol
 
       - name: Install Dependencies
         run: |

--- a/datamol/isomers/_enumerate.py
+++ b/datamol/isomers/_enumerate.py
@@ -55,6 +55,7 @@ def enumerate_stereoisomers(
     undefined_only: bool = False,
     rationalise: bool = True,
     timeout_seconds: int = None,
+    clean_it: bool = True,
 ):
     """Enumerate the stereocenters and bonds of the current molecule.
 
@@ -72,14 +73,17 @@ def enumerate_stereoisomers(
         timeout_seconds: The maximum amount of time to spend on enumeration. None
             will disable the timeout. Note that the timeout might be inaccurate as a running single variant
             computation is not stopped when the duration is reached.
+        clean_it: rdkit flag for assigning stereochemistry. If True, will remove previous stereochemistry
+         markings on the bonds.
+
     """
 
     # safety first
     mol = dm.copy_mol(mol)
 
     # in case any bonds/centers are missing stereo chem flag it here
-    Chem.AssignStereochemistry(mol, force=False, flagPossibleStereoCenters=True, cleanIt=True)  # type: ignore
-    Chem.FindPotentialStereoBonds(mol, cleanIt=True)  # type: ignore
+    Chem.AssignStereochemistry(mol, force=False, flagPossibleStereoCenters=True, cleanIt=clean_it)  # type: ignore
+    Chem.FindPotentialStereoBonds(mol, cleanIt=clean_it)  # type: ignore
 
     # set up the options
     stereo_opts = StereoEnumerationOptions(

--- a/datamol/isomers/_enumerate.py
+++ b/datamol/isomers/_enumerate.py
@@ -73,9 +73,8 @@ def enumerate_stereoisomers(
         timeout_seconds: The maximum amount of time to spend on enumeration. None
             will disable the timeout. Note that the timeout might be inaccurate as a running single variant
             computation is not stopped when the duration is reached.
-        clean_it: rdkit flag for assigning stereochemistry. If True, will remove previous stereochemistry
-         markings on the bonds.
-
+        clean_it: A flag for assigning stereochemistry. If True, it will remove previous stereochemistry
+            markings on the bonds.
     """
 
     # safety first

--- a/datamol/isomers/_enumerate.py
+++ b/datamol/isomers/_enumerate.py
@@ -113,7 +113,7 @@ def enumerate_stereoisomers(
     for isomer in isomers:
         # isomer has CIS/TRANS tags so convert back to E/Z
         Chem.SetDoubleBondNeighborDirections(isomer)  # type: ignore
-        Chem.AssignStereochemistry(isomer, force=True, cleanIt=True)  # type: ignore
+        Chem.AssignStereochemistry(isomer, force=True, cleanIt=clean_it)  # type: ignore
         variants.append(isomer)
 
     return variants

--- a/news/stereo_flag.rst
+++ b/news/stereo_flag.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Expose the clean_it flag when enumerating stereoisomers.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/tests/test_isomers.py
+++ b/tests/test_isomers.py
@@ -27,6 +27,17 @@ def test_enumerate_stereo():
     }
 
 
+def test_enumerate_stereo_undefined_failure():
+    mol = dm.to_mol(
+        "N=1C(NC2CC2)=C3C(=NC1)N(/C=C/C=4C=C(C=CC4C)C(=O)NC=5C=C(C=C(C5)N6CCN(CC6)C)C(F)(F)F)C=N3"
+    )
+    with pytest.raises(RuntimeError):
+        dm.enumerate_stereoisomers(mol, clean_it=True)
+
+    mols = dm.enumerate_stereoisomers(mol, clean_it=False)
+    assert len(mols) == 2  # only one double bond
+
+
 def test_enumerate_stereo_timeout():
     mol = dm.to_mol(
         "CC1=C2C(C(=O)C3(C(CC4C(C3C(C(C2(C)C)(CC1OC(=O)C(C(C5=CC=CC=C5)NC(=O)C6=CC=CC=C6)O)O)OC(=O)C7=CC=CC=C7)(CO4)OC(=O)C)O)C)OC(=O)C"

--- a/tests/test_utils_jobs.py
+++ b/tests/test_utils_jobs.py
@@ -87,7 +87,7 @@ class TestJobs(unittest.TestCase):
 
     def test_parallelized(self):
         def fn(x):
-            return x ** 2
+            return x**2
 
         results = dm.parallelized(
             fn,
@@ -120,7 +120,7 @@ class TestJobs(unittest.TestCase):
 
     def test_job_kwargs(self):
         def fn(x):
-            return x ** 2
+            return x**2
 
         results = dm.parallelized(
             fn,
@@ -135,7 +135,7 @@ class TestJobs(unittest.TestCase):
 
     def test_tqdm_kwargs(self):
         def fn(x):
-            return x ** 2
+            return x**2
 
         results = dm.parallelized(
             fn,


### PR DESCRIPTION
Exposing this arg can prevent errors for certain problematic molecules when enumerating stereochemistry.

E.g.

```
sm = "N=1C(NC2CC2)=C3C(=NC1)N(/C=C/C=4C=C(C=CC4C)C(=O)NC=5C=C(C=C(C5)N6CCN(CC6)C)C(F)(F)F)C=N3"
mol = datamol.to_mol(sm)

datamol.enumerate_stereoisomers(mol) # Fails
datamol.enumerate_stereoisomers(mol, clean_it=False) # Succeeds
```