### PR TITLE
Fix bug in unique id

### DIFF
--- a/datamol/convert.py
+++ b/datamol/convert.py
@@ -91,12 +91,12 @@ def to_selfies(mol: Union[str, dm.Mol]) -> Optional[str]:
     Returns:
         selfies: SELFIES string.
     """
-    if mol is None:
-        return None
 
     if isinstance(mol, dm.Mol):
         mol = to_smiles(mol)
 
+    if mol is None:
+        return None
     selfies = sf.encoder(mol)  # type: ignore
 
     if selfies == -1:
@@ -139,11 +139,11 @@ def smiles_as_smarts(mol: Union[str, dm.Mol], keep_hs: bool = True) -> Optional[
         smarts of the molecule
     """
 
-    if mol is None:
-        return None
-
     if isinstance(mol, str):
         mol = dm.to_mol(mol)
+
+    if mol is None:
+        return None
 
     # Change the isotope to 99
     for atom in mol.GetAtoms():  # type: ignore
@@ -171,13 +171,17 @@ def to_inchi(mol: Union[str, dm.Mol]) -> Optional[str]:
         mol: a molecule.
     """
 
-    if mol is None:
-        return None
-
     if isinstance(mol, str):
         mol = dm.to_mol(mol)
 
-    return Chem.MolToInchi(mol)
+    if mol is None:
+        return None
+
+    inchi_val = Chem.MolToInchi(mol)
+    if not inchi_val:
+        logger.warning("Inchi computation failed, setting output to None")
+        return None
+    return inchi_val
 
 
 def to_inchi_non_standard(
@@ -211,11 +215,11 @@ def to_inchi_non_standard(
             `["/SRel", "/AuxNone"]`.
     """
 
-    if mol is None:
-        return None
-
     if isinstance(mol, str):
         mol = dm.to_mol(mol)
+
+    if mol is None:
+        return None
 
     inchi_options = _process_inchi_options(
         fixed_hydrogen_layer=fixed_hydrogen_layer,
@@ -226,7 +230,11 @@ def to_inchi_non_standard(
         options=options,
     )
 
-    return Chem.MolToInchi(mol, options=inchi_options)
+    inchi_val = Chem.MolToInchi(mol, options=inchi_options)
+    if not inchi_val:
+        logger.warning("Inchi computation failed, setting output to None")
+        return None
+    return inchi_val
 
 
 def to_smarts(mol: dm.Mol) -> Optional[str]:
@@ -248,14 +256,17 @@ def to_inchikey(mol: Union[str, dm.Mol]) -> Optional[str]:
     Args:
         mol: a molecule
     """
+    if isinstance(mol, str):
+        mol = dm.to_mol(mol)
 
     if mol is None:
         return None
 
-    if isinstance(mol, str):
-        mol = dm.to_mol(mol)
-
-    return Chem.MolToInchiKey(mol)
+    inchikey = Chem.MolToInchiKey(mol)
+    if not inchikey:
+        logger.warning("Inchikey computation failed, setting output to None")
+        return None
+    return inchikey
 
 
 def to_inchikey_non_standard(
@@ -289,11 +300,11 @@ def to_inchikey_non_standard(
             `["/SRel", "/AuxNone"]`.
     """
 
-    if mol is None:
-        return None
-
     if isinstance(mol, str):
         mol = dm.to_mol(mol)
+
+    if mol is None:
+        return None
 
     inchi_options = _process_inchi_options(
         fixed_hydrogen_layer=fixed_hydrogen_layer,
@@ -304,7 +315,11 @@ def to_inchikey_non_standard(
         options=options,
     )
 
-    return Chem.MolToInchiKey(mol, options=inchi_options)
+    inchikey = Chem.MolToInchiKey(mol, options=inchi_options)
+    if not inchikey:
+        logger.warning("Non standard inchikey computation failed, setting output to None")
+        return None
+    return inchikey
 
 
 def from_inchi(

--- a/datamol/convert.py
+++ b/datamol/convert.py
@@ -179,7 +179,6 @@ def to_inchi(mol: Union[str, dm.Mol]) -> Optional[str]:
 
     inchi_val = Chem.MolToInchi(mol)
     if not inchi_val:
-        logger.warning("Inchi computation failed, setting output to None")
         return None
     return inchi_val
 
@@ -232,7 +231,6 @@ def to_inchi_non_standard(
 
     inchi_val = Chem.MolToInchi(mol, options=inchi_options)
     if not inchi_val:
-        logger.warning("Inchi computation failed, setting output to None")
         return None
     return inchi_val
 
@@ -264,7 +262,6 @@ def to_inchikey(mol: Union[str, dm.Mol]) -> Optional[str]:
 
     inchikey = Chem.MolToInchiKey(mol)
     if not inchikey:
-        logger.warning("Inchikey computation failed, setting output to None")
         return None
     return inchikey
 
@@ -317,7 +314,6 @@ def to_inchikey_non_standard(
 
     inchikey = Chem.MolToInchiKey(mol, options=inchi_options)
     if not inchikey:
-        logger.warning("Non standard inchikey computation failed, setting output to None")
         return None
     return inchikey
 

--- a/news/unique-id-bug.rst
+++ b/news/unique-id-bug.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Support for selfies<2.0.0 in tests
+
+**Changed:**
+
+* Behaviour of all *inchi* functions to return None with a warning instead of silently returning an empty string
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Bug in unique_id making this evaluation falling back on 'd41d8cd98f00b204e9800998ecf8427e' on unsupported inputs. Instead None is returned now
+
+**Security:**
+
+* <news item>

--- a/news/unique-id-bug.rst
+++ b/news/unique-id-bug.rst
@@ -5,6 +5,7 @@
 **Changed:**
 
 * Behaviour of all *inchi* functions to return None with a warning instead of silently returning an empty string
+* Order of str evaluation on convertion function. `isinstance(str)` is now evaluated before `is None`
 
 **Deprecated:**
 

--- a/tests/test_mol.py
+++ b/tests/test_mol.py
@@ -485,11 +485,14 @@ def test_unique_id():
         # of the same molecule.
         "N=C(N)O",
         "NC(N)=O",
+        # an invalid molecule
+        "C(C)(C)(C)(C)(C)",
+        # a molecule with a dummy atom
+        "CCCC*",
     ]
 
     mols = [dm.to_mol(s) for s in smiles_list]
     ids = [dm.unique_id(m) for m in mols]
-
     assert ids == [
         "2f0a84f817a369e79a2b44085ebe3a27",
         "3dc94b495eba316c2df4563457c77842",
@@ -509,4 +512,9 @@ def test_unique_id():
         # The two IDS of the tautomers are indeed different.
         "3a04e3e47b86287b035b4affe84dff91",
         "943d4548ef05069b79e929ed140ce905",
+        # unsupported syntax should return None
+        None,
+        None,
     ]
+
+    assert dm.unique_id(None) is None


### PR DESCRIPTION
Checklist:

- [x] Add tests to cover the fixed bug(s) or the new introduced feature(s) (if appropriate).
- [ ] Update the API documentation is a new function is added or an existing one is deleted.
- [x] Added a `news` entry.
  - _copy `news/TEMPLATE.rst` to `news/my-feature-or-branch.rst`) and edit it._

---

PR to fix this bug essentially.

```python
dm.unique_id("CCCCCCCC[*]") == dm.unique_id("C1CNNC1[*]") == dm.unique_id("") == 'd41d8cd98f00b204e9800998ecf8427e'
```

New behaviour returns `None`

Also fixed evaluation order on input. Conversion to `dm.Mol` is now performed before checking if `None`