### PR TITLE
correct "ecfp" default args to generate ECFP rather than FCFP

### DIFF
--- a/datamol/fp.py
+++ b/datamol/fp.py
@@ -56,7 +56,7 @@ _FP_DEFAULT_ARGS = {
         "fromAtoms": [],
         "useChirality": False,
         "useBondTypes": True,
-        "useFeatures": True,
+        "useFeatures": False
     },
     "fcfp": {
         "radius": 2,  # FCFP4

--- a/datamol/fp.py
+++ b/datamol/fp.py
@@ -56,7 +56,7 @@ _FP_DEFAULT_ARGS = {
         "fromAtoms": [],
         "useChirality": False,
         "useBondTypes": True,
-        "useFeatures": False
+        "useFeatures": False,
     },
     "fcfp": {
         "radius": 2,  # FCFP4

--- a/news/ecfp_fix.rst
+++ b/news/ecfp_fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Errors in ECFP fingerprints that computes FCFP instead of ECFP.
+
+**Security:**
+
+* <news item>

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -47,7 +47,7 @@ def test_auto_align_many():
     data: pd.DataFrame = dm.solubility(as_df=True)  # type: ignore
     data = data.iloc[:32].copy()  # type: ignore
 
-    excepted_cluster_size = [4, 9, 5, 9, 9]
+    excepted_cluster_size = [17, 9, 5, 9, 9]
 
     for i, partition_method in enumerate(
         [

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -13,7 +13,7 @@ def test_cluster_mols():
     mols = [dm.to_mol(s) for s in smiles]
 
     _, mol_clusters = dm.cluster_mols(mols, cutoff=0.7)
-    cluster_sizes = [15, 12, 3, 6, 9, 9, 4, 1, 4, 3, 3, 2, 3]
+    cluster_sizes = [11, 7, 5, 3, 3, 3, 2, 3, 2, 1, 2, 2, 1]
     assert [len(c) for c in mol_clusters[:13]] == cluster_sizes
 
 
@@ -27,7 +27,7 @@ def test_pick_diverse():
     indices, _ = dm.pick_diverse(mols, npick=18, seed=19)
 
     excepted_indices = np.array(
-        [9, 43, 32, 89, 74, 96, 42, 91, 17, 67, 56, 94, 98, 16, 66, 58, 93, 3]
+        [9, 14, 47, 50, 56, 61, 67, 89, 83, 90, 94, 10, 0, 96, 15, 58, 71, 21]
     )
 
     assert np.all(indices == excepted_indices)
@@ -40,7 +40,7 @@ def test_pick_centroids():
     indices, centroids = dm.pick_centroids(
         mols, npick=18, threshold=0.7, method="sphere", n_jobs=-1
     )
-    excepted_indices = np.array([0, 1, 2, 3, 4, 5, 8, 11, 13, 15, 16, 17, 18, 19, 21, 23, 25, 32])
+    excepted_indices = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17, 18, 20])
 
     assert np.all(indices == excepted_indices)
 

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -11,7 +11,7 @@ def test_to_fp():
     mol = dm.to_mol(smiles)
 
     assert dm.to_fp(mol).shape[0] == 2048
-    assert dm.to_fp(mol).sum() == 29
+    assert dm.to_fp(mol).sum() == 31
 
 
 def test_list_fp():
@@ -60,7 +60,7 @@ def test_all_fps():
 
     assert fp_infos == {
         "maccs": {"size": 167, "bits_sum": 21},
-        "ecfp": {"size": 2048, "bits_sum": 29},
+        "ecfp": {"size": 2048, "bits_sum": 31},
         "topological": {"size": 2048, "bits_sum": 18},
         "atompair": {"size": 2048, "bits_sum": 68},
         "rdkit": {"size": 2048, "bits_sum": 354},

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -13,12 +13,12 @@ def test_pdist():
     dist_mat = dm.pdist(mols)
 
     assert dist_mat.shape == (3, 3)
-    assert dist_mat.sum() == 5.661904761904761
+    assert dist_mat.sum() == 5.6757105943152455
 
     dist_mat = dm.pdist(mols, n_jobs=None)
 
     assert dist_mat.shape == (3, 3)
-    assert dist_mat.sum() == 5.661904761904761
+    assert dist_mat.sum() == 5.6757105943152455
 
 
 def test_pdist_condensed():
@@ -28,7 +28,7 @@ def test_pdist_condensed():
     dist_mat = dm.pdist(mols, squareform=False)
 
     assert dist_mat.shape == (3,)
-    assert dist_mat.sum() == 2.8309523809523807
+    assert dist_mat.sum() == 2.8378552971576227
 
 
 def test_cdist():
@@ -46,7 +46,7 @@ def test_cdist():
     dist_mat = dm.cdist(mols1, mols2)
 
     assert dist_mat.shape == (3, 3)
-    assert np.isclose(dist_mat.mean(), 0.9416646866643121)
+    assert np.isclose(dist_mat.mean(), 0.9416270180919872)
 
 
 def test_cdist_chunked():


### PR DESCRIPTION
Bug fix: default arguments in fp.py led to calculation of feature fingerprints (FCFP) when invoked with 'ecfp' argument.  Corrected to generate ECFP fingerprints.
